### PR TITLE
Base64 Support

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -68,6 +68,7 @@ func TestParseField(t *testing.T) {
 		"LinkTo":     {"https://rotational.io", &CustomURL{Value: r8l}},
 		"EmptyMap":   {"", map[string]int{}},
 		"EmptySlice": {"", []string{}},
+		"ByteSlice":  {"n2LeUR98zrfDdAcJAu58Eg==", []byte{0x9f, 0x62, 0xde, 0x51, 0x1f, 0x7c, 0xce, 0xb7, 0xc3, 0x74, 0x7, 0x9, 0x2, 0xee, 0x7c, 0x12}},
 	}
 
 	for _, field := range s.Fields() {
@@ -103,6 +104,7 @@ type Specification struct {
 	LinkTo     *CustomURL
 	EmptyMap   map[string]int
 	EmptySlice []string
+	ByteSlice  []byte
 }
 
 type Color [3]uint8


### PR DESCRIPTION
### Scope of changes

Adds base64 encoding support for `[]byte` and `encoding.BinaryUnmarshaler`. 

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)
