### PR TITLE
Fix Required Validation of Nested Configs

### DIFF
--- a/usage/usage.go
+++ b/usage/usage.go
@@ -98,13 +98,13 @@ var (
 
 func implementsInterface(t reflect.Type) bool {
 	return t.Implements(decoderType) ||
-		reflect.PtrTo(t).Implements(decoderType) ||
+		reflect.PointerTo(t).Implements(decoderType) ||
 		t.Implements(setterType) ||
-		reflect.PtrTo(t).Implements(setterType) ||
+		reflect.PointerTo(t).Implements(setterType) ||
 		t.Implements(textUnmarshalerType) ||
-		reflect.PtrTo(t).Implements(textUnmarshalerType) ||
+		reflect.PointerTo(t).Implements(textUnmarshalerType) ||
 		t.Implements(binaryUnmarshalerType) ||
-		reflect.PtrTo(t).Implements(binaryUnmarshalerType)
+		reflect.PointerTo(t).Implements(binaryUnmarshalerType)
 }
 
 // toTypeDescription converts Go types into a human readable description

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -59,9 +59,30 @@ func Gather(spec interface{}) (infos []Info, err error) {
 
 	infos = make([]Info, 0, s.NumField())
 	for _, field := range s.Fields() {
+		// If the field is unexported, skip the field
+		if !field.IsExported() {
+			continue
+		}
+
 		// If the ignored tag is set or the validator is set to ignored, skip the field
 		if isTrue(field.Tag(tagIgnored)) || ignoreValidation(field.Tag(tagValidator)) {
 			continue
+		}
+
+		// Handle pointers if necessary
+		for field.Kind() == reflect.Pointer {
+			if field.IsNil() {
+				if field.TypeKind() != reflect.Struct {
+					// nil pointer to a non-struct: leave it alone.
+					break
+				}
+
+				// nil pointer to a struct: create a zero-instance
+				if err = field.Init(); err != nil {
+					panic(fmt.Errorf("could not create zero instance: %w", err))
+				}
+			}
+			field = field.Elem()
 		}
 
 		// If this is a struct then gather validators for the nested fields

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -3,6 +3,7 @@ package validate
 import (
 	goerrors "errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -63,6 +64,15 @@ func Gather(spec interface{}) (infos []Info, err error) {
 			continue
 		}
 
+		// If this is a struct then gather validators for the nested fields
+		if field.Kind() == reflect.Struct {
+			var subinfos []Info
+			if subinfos, err = Gather(field.Pointer()); err != nil {
+				return nil, err
+			}
+			infos = append(infos, subinfos...)
+		}
+
 		// Chain validators together if necessary
 		validators := make([]Validator, 0, 3)
 
@@ -106,7 +116,7 @@ func Gather(spec interface{}) (infos []Info, err error) {
 }
 
 type Info struct {
-	Field    *structs.Field // The actual field to set the envvar from (along with tags)
+	Field    *structs.Field // The actual field to get the validation info from (along with tags)
 	Validate Validator      // The validator to apply to the field
 }
 

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -109,6 +109,66 @@ func TestNestedRequired(t *testing.T) {
 	assert.Ok(t, err)
 }
 
+func TestNestedFieldsRequired(t *testing.T) {
+	type Specification struct {
+		Nested NestedRequired
+	}
+
+	invalid := &Specification{}
+	err := validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropC: "baz"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropA: "foo"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropB: 32}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	valid := &Specification{Nested: NestedRequired{PropA: "foo", PropB: 32}}
+	err = validate.Validate(valid)
+	assert.Ok(t, err)
+}
+
+func TestNestedPointerRequired(t *testing.T) {
+	type Specification struct {
+		Nested *NestedRequired
+	}
+
+	invalid := &Specification{}
+	err := validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: &NestedRequired{}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: &NestedRequired{PropC: "baz"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: &NestedRequired{PropA: "foo"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: &NestedRequired{PropB: 32}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	valid := &Specification{Nested: &NestedRequired{PropA: "foo", PropB: 32}}
+	err = validate.Validate(valid)
+	assert.Ok(t, err)
+}
+
 func TestRequiredTypes(t *testing.T) {
 	type Specification struct {
 		Ptr       *string        `required:"true"`

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -79,6 +79,36 @@ func TestRequired(t *testing.T) {
 	assert.Ok(t, err)
 }
 
+func TestNestedRequired(t *testing.T) {
+	type Specification struct {
+		Nested NestedRequired `required:"true"`
+	}
+
+	invalid := &Specification{}
+	err := validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropC: "baz"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropA: "foo"}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	invalid = &Specification{Nested: NestedRequired{PropB: 32}}
+	err = validate.Validate(invalid)
+	assert.Assert(t, err != nil, "expected a validation error to have occurred")
+
+	valid := &Specification{Nested: NestedRequired{PropA: "foo", PropB: 32}}
+	err = validate.Validate(valid)
+	assert.Ok(t, err)
+}
+
 func TestRequiredTypes(t *testing.T) {
 	type Specification struct {
 		Ptr       *string        `required:"true"`
@@ -148,6 +178,7 @@ type Nested struct {
 type NestedRequired struct {
 	PropA string `required:"true"`
 	PropB int64  `required:"true"`
+	PropC string
 }
 
 type Age int


### PR DESCRIPTION
### Scope of changes

Fixes a bug where "required" fields in nested configs were not being properly validated. Adds tests to make sure that nested structs and pointers are correctly validated and also adds a real world example just to make sure the configuration is happening correctly.

Fixes SC-20430

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?