### PR TITLE
Vanity Package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       GOBIN: ${{ github.workspace }}/go/bin
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/rotationalio/confire
+        working-directory: ${{ env.GOPATH }}/src/go.rtnl.ai/confire
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          path: ${{ env.GOPATH }}/src/github.com/rotationalio/confire
+          path: ${{ env.GOPATH }}/src/go.rtnl.ai/confire
 
       - name: Install Staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
@@ -47,7 +47,7 @@ jobs:
       GOBIN: ${{ github.workspace }}/go/bin
     defaults:
       run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/rotationalio/confire
+        working-directory: ${{ env.GOPATH }}/src/go.rtnl.ai/confire
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          path: ${{ env.GOPATH }}/src/github.com/rotationalio/confire
+          path: ${{ env.GOPATH }}/src/go.rtnl.ai/confire
 
       - name: Install Dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Confire
 
 [![Go Reference](https://pkg.go.dev/badge/go.rtnl.ai/confire.svg)](https://pkg.go.dev/go.rtnl.ai/confire)
-[![Tests](https://go.rtnl.ai/confire/actions/workflows/test.yaml/badge.svg)](https://go.rtnl.ai/confire/actions/workflows/test.yaml)
+[![Tests](https://github.com/rotationalio/confire/actions/workflows/test.yaml/badge.svg)](https://github.com/rotationalio/confire/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/go.rtnl.ai/confire)](https://goreportcard.com/report/go.rtnl.ai/confire)
 
 **Configuration management for services and distributed systems**
@@ -233,7 +233,7 @@ confire.Process(&conf, confire.NoEnv)
 Configuration structs get big fast, and it can be a real pain to manage them. To provide some assistance, confire provides a method for printing out the environment variables, types, required validation, and default values from your struct tags:
 
 ```go
-import "go.rtnl.ai/confire/usage"
+import "github.com/rotationalio/confire/usage"
 
 type Config struct {
 	Debug   bool

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Confire
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/rotationalio/confire.svg)](https://pkg.go.dev/github.com/rotationalio/confire)
-[![Tests](https://github.com/rotationalio/confire/actions/workflows/test.yaml/badge.svg)](https://github.com/rotationalio/confire/actions/workflows/test.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/rotationalio/confire)](https://goreportcard.com/report/github.com/rotationalio/confire)
+[![Go Reference](https://pkg.go.dev/badge/go.rtnl.ai/confire.svg)](https://pkg.go.dev/go.rtnl.ai/confire)
+[![Tests](https://go.rtnl.ai/confire/actions/workflows/test.yaml/badge.svg)](https://go.rtnl.ai/confire/actions/workflows/test.yaml)
+[![Go Report Card](https://goreportcard.com/badge/go.rtnl.ai/confire)](https://goreportcard.com/report/go.rtnl.ai/confire)
 
 **Configuration management for services and distributed systems**
 
 ## Install
 
 ```
-$ go get github.com/rotationalio/confire
+$ go get go.rtnl.ai/confire
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/rotationalio/confire"
+	"go.rtnl.ai/confire"
 )
 
 type Config struct {
@@ -120,8 +120,8 @@ Currently confire supports parsing these struct field types:
 - maps (keys and values of any supported type)
 - [encoding.TextUnmarshaler](https://golang.org/pkg/encoding/#TextUnmarshaler)
 - [encoding.BinaryUnmarshaler](https://golang.org/pkg/encoding/#BinaryUnmarshaler)
-- [parse.Decoder](https://pkg.go.dev/github.com/rotationalio/confire/parse#Decoder)
-- [parse.Setter](https://pkg.go.dev/github.com/rotationalio/confire/parse#Setter)
+- [parse.Decoder](https://pkg.go.dev/go.rtnl.ai/confire/parse#Decoder)
+- [parse.Setter](https://pkg.go.dev/go.rtnl.ai/confire/parse#Setter)
 
 Note that `time.Time` is also supported because it implements `encoding.TextUnmarshaler`.
 
@@ -134,7 +134,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/rotationalio/confire/defaults"
+	"go.rtnl.ai/confire/defaults"
 )
 
 type Config struct {
@@ -170,7 +170,7 @@ Coming soon!
 Confire automatically looks for an environment variable to set on your configuration struct based on the name of the struct variable. Consider the following go code:
 
 ```go
-import "github.com/rotationalio/confire/env"
+import "go.rtnl.ai/confire/env"
 
 type Config struct {
 	Enabled    bool
@@ -233,7 +233,7 @@ confire.Process(&conf, confire.NoEnv)
 Configuration structs get big fast, and it can be a real pain to manage them. To provide some assistance, confire provides a method for printing out the environment variables, types, required validation, and default values from your struct tags:
 
 ```go
-import "github.com/rotationalio/confire/usage"
+import "go.rtnl.ai/confire/usage"
 
 type Config struct {
 	Debug   bool

--- a/confire.go
+++ b/confire.go
@@ -1,9 +1,9 @@
 package confire
 
 import (
-	"github.com/rotationalio/confire/defaults"
-	"github.com/rotationalio/confire/env"
-	"github.com/rotationalio/confire/validate"
+	"go.rtnl.ai/confire/defaults"
+	"go.rtnl.ai/confire/env"
+	"go.rtnl.ai/confire/validate"
 )
 
 // Process is the main entry point to configuring and validating a struct from defaults

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -8,9 +8,9 @@ package defaults
 import (
 	"reflect"
 
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/parse"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/parse"
+	"go.rtnl.ai/confire/structs"
 )
 
 const tagDefault = "default"

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/defaults"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/defaults"
 )
 
 type Specification struct {

--- a/env/env.go
+++ b/env/env.go
@@ -16,9 +16,9 @@ import (
 
 	goerrs "errors"
 
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/parse"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/parse"
+	"go.rtnl.ai/confire/structs"
 )
 
 const (

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	. "github.com/rotationalio/confire/env"
+	"go.rtnl.ai/confire/assert"
+	. "go.rtnl.ai/confire/env"
 )
 
 const testPrefix = "confire"

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,7 @@ package confire
 import (
 	"errors"
 
-	confireErrors "github.com/rotationalio/confire/errors"
+	confireErrors "go.rtnl.ai/confire/errors"
 )
 
 // Extract a parse error from an error if it is one.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rotationalio/confire/assert"
-	. "github.com/rotationalio/confire/errors"
+	"go.rtnl.ai/confire/assert"
+	. "go.rtnl.ai/confire/errors"
 )
 
 func TestParseError(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -3,9 +3,9 @@ package confire_test
 import (
 	"testing"
 
-	"github.com/rotationalio/confire"
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/errors"
+	"go.rtnl.ai/confire"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/errors"
 )
 
 func TestParserError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rotationalio/confire
+module go.rtnl.ai/confire
 
 go 1.20

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/structs"
 )
 
 // Merge updates the destination struct in-place with non-zero values from the source.

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/merge"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/merge"
 )
 
 func TestMerge(t *testing.T) {

--- a/parse/iface.go
+++ b/parse/iface.go
@@ -4,7 +4,7 @@ import (
 	"encoding"
 	"reflect"
 
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/structs"
 )
 
 // Decoder has the same semantics as Setter, but takes higher precedence.

--- a/parse/iface_test.go
+++ b/parse/iface_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding"
 	"testing"
 
-	"github.com/rotationalio/confire/assert"
-	. "github.com/rotationalio/confire/parse"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/assert"
+	. "go.rtnl.ai/confire/parse"
+	"go.rtnl.ai/confire/structs"
 )
 
 type Does struct{}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/structs"
 )
 
 func Parse(value string, field reflect.Value) error {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/parse"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/parse"
+	"go.rtnl.ai/confire/structs"
 )
 
 func TestParse(t *testing.T) {

--- a/structs/field.go
+++ b/structs/field.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/rotationalio/confire/errors"
+	"go.rtnl.ai/confire/errors"
 )
 
 func getFields(v reflect.Value) (fields []*Field) {

--- a/structs/field_test.go
+++ b/structs/field_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/structs"
 )
 
 func TestFieldMethods(t *testing.T) {

--- a/structs/iface_test.go
+++ b/structs/iface_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/structs"
 )
 
 func TestTimeIsZero(t *testing.T) {

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/rotationalio/confire/errors"
+	"go.rtnl.ai/confire/errors"
 )
 
 // Struct encapsulates a struct type to provide reflection around the struct.

--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/structs"
 )
 
 func TestNewIsPointer(t *testing.T) {

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/rotationalio/confire/env"
-	"github.com/rotationalio/confire/parse"
+	"go.rtnl.ai/confire/env"
+	"go.rtnl.ai/confire/parse"
 )
 
 const (

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -12,8 +12,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	"github.com/rotationalio/confire/usage"
+	"go.rtnl.ai/confire/assert"
+	"go.rtnl.ai/confire/usage"
 )
 
 func TestUsageDefault(t *testing.T) {

--- a/validate/required.go
+++ b/validate/required.go
@@ -1,8 +1,8 @@
 package validate
 
 import (
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/structs"
 )
 
 // Required returns a validation error if the specified field is zero valued.

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/structs"
+	"go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/structs"
 )
 
 const (

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rotationalio/confire/assert"
-	confireErrors "github.com/rotationalio/confire/errors"
-	"github.com/rotationalio/confire/validate"
+	"go.rtnl.ai/confire/assert"
+	confireErrors "go.rtnl.ai/confire/errors"
+	"go.rtnl.ai/confire/validate"
 )
 
 func TestValidator(t *testing.T) {


### PR DESCRIPTION
### Scope of changes

Converts Confire to `go.rtnl.ai/confire` as a vanity package.

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [x] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have added new test fixtures as needed to support added tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a module/import-path migration and CI/doc updates; risk is limited to downstream breakage if consumers still import the old path or if any references were missed.
> 
> **Overview**
> Migrates the project from `github.com/rotationalio/confire` to the vanity module path `go.rtnl.ai/confire` by updating `go.mod` and rewriting internal imports across packages and tests.
> 
> Updates CI (`.github/workflows/test.yaml`) and README badges/examples to use the new checkout path and import/go-get instructions, keeping behavior otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e3005e6c6a7768f40ef9a4c000b405a3b6b361. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->